### PR TITLE
Add TodoService and its tests

### DIFF
--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,17 @@
+import pytest
+
+from todo import TodoService
+
+
+def test_add_item_increments_id():
+    service = TodoService()
+    first = service.add_item("task1")
+    second = service.add_item("task2")
+    assert first["id"] == 1
+    assert second["id"] == 2
+
+
+def test_add_item_empty_text_raises():
+    service = TodoService()
+    with pytest.raises(ValueError):
+        service.add_item("")

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,10 @@
+class TodoService:
+    def __init__(self):
+        self._items: list[dict] = []
+
+    def add_item(self, text: str) -> dict:
+        if not text:
+            raise ValueError("Text cannot be empty")
+        item = {"id": len(self._items) + 1, "text": text}
+        self._items.append(item)
+        return item


### PR DESCRIPTION
## Summary
- implement simple `TodoService` with in-memory items list
- add pytest coverage for success case and failure case

## Testing
- `python3 -m pytest -q tests/test_todo.py` *(fails: No module named pytest)*